### PR TITLE
WebSocket Session Management Refactor & Analytics

### DIFF
--- a/Sources/UI/ActiveChatView.swift
+++ b/Sources/UI/ActiveChatView.swift
@@ -137,15 +137,21 @@ public struct ActiveChatView: View {
         await viewModel.checkandValidateWebSocketConnection()
       }
     }
+    .onChange(of: viewModel.chatErrorState) { _, newState in
+      guard newState != .none else { return }
+      DocAssistEventManager.shared.trackEvent(
+        event: .docAssistLandingPgClick,
+        properties: [
+          "type": "session_recovery_banner_shown",
+          "session_id": viewModel.vmssid,
+          "error_state": String(describing: newState),
+          "error_reason": viewModel.lastSessionRecoveryReason ?? "unknown",
+          "error_message": viewModel.webSocketErrorMessage ?? ""
+        ]
+      )
+    }
     .onDisappear {
       viewModel.inputString = ""
-      let sessionToCheck = session
-      Task {
-        let hasMessages = await DatabaseConfig.shared.hasMessages(forSessionId: sessionToCheck)
-        if !hasMessages {
-          await DatabaseConfig.shared.deleteSession(sessionId: sessionToCheck)
-        }
-      }
     }
   }
   
@@ -161,15 +167,50 @@ public struct ActiveChatView: View {
         Task {
           if viewModel.chatErrorState == .connectionError {
             let sessionId = viewModel.vmssid
+            DocAssistEventManager.shared.trackEvent(
+              event: .docAssistLandingPgClick,
+              properties: [
+                "type": "session_recovery_retry_clicked",
+                "session_id": sessionId,
+                "error_reason": viewModel.lastSessionRecoveryReason ?? "unknown"
+              ]
+            )
             if let newToken = await viewModel.refreshSession(for: sessionId) {
               await viewModel.webSocketAuthentication(sessionId: sessionId, sessionToken: newToken)
+              DocAssistEventManager.shared.trackEvent(
+                event: .docAssistLandingPgClick,
+                properties: [
+                  "type": "session_recovery_retry_success",
+                  "session_id": sessionId,
+                  "error_reason": viewModel.lastSessionRecoveryReason ?? "unknown"
+                ]
+              )
+              viewModel.lastSessionRecoveryReason = nil
               viewModel.webSocketErrorMessage = nil
               viewModel.chatErrorState = .none
             } else {
+              DocAssistEventManager.shared.trackEvent(
+                event: .docAssistLandingPgClick,
+                properties: [
+                  "type": "session_recovery_retry_failed",
+                  "session_id": sessionId,
+                  "error_reason": viewModel.lastSessionRecoveryReason ?? "unknown"
+                ]
+              )
               viewModel.webSocketErrorMessage = "Session not found. Please start a new session."
+              viewModel.lastSessionRecoveryReason = "refresh_failed_after_retry"
               viewModel.chatErrorState = .sessionExpired
             }
           } else {
+            let oldSessionId = viewModel.vmssid
+            DocAssistEventManager.shared.trackEvent(
+              event: .docAssistLandingPgClick,
+              properties: [
+                "type": "session_recovery_start_new_clicked",
+                "session_id": oldSessionId,
+                "error_reason": viewModel.lastSessionRecoveryReason ?? "unknown"
+              ]
+            )
             viewModel.chatErrorState = .none
             viewModel.webSocketErrorMessage = nil
             let newSessionId = await viewModel.createNewSession(
@@ -178,6 +219,15 @@ public struct ActiveChatView: View {
               userBId: userBId
             )
             if !newSessionId.isEmpty {
+              DocAssistEventManager.shared.trackEvent(
+                event: .docAssistLandingPgClick,
+                properties: [
+                  "type": "session_recovery_start_new_success",
+                  "session_id": newSessionId,
+                  "previous_session_id": oldSessionId
+                ]
+              )
+              viewModel.lastSessionRecoveryReason = nil
               session = newSessionId
             }
           }

--- a/Sources/UI/ActiveChatView.swift
+++ b/Sources/UI/ActiveChatView.swift
@@ -160,7 +160,7 @@ public struct ActiveChatView: View {
       Button {
         Task {
           if viewModel.chatErrorState == .connectionError {
-            let sessionId = UserDefaults.standard.string(forKey: "SessionId") ?? viewModel.vmssid
+            let sessionId = viewModel.vmssid
             if let newToken = await viewModel.refreshSession(for: sessionId) {
               await viewModel.webSocketAuthentication(sessionId: sessionId, sessionToken: newToken)
               viewModel.webSocketErrorMessage = nil

--- a/Sources/UI/ActiveChatView.swift
+++ b/Sources/UI/ActiveChatView.swift
@@ -137,8 +137,9 @@ public struct ActiveChatView: View {
         await viewModel.checkandValidateWebSocketConnection()
       }
     }
-    .onChange(of: viewModel.chatErrorState) { _, newState in
-      guard newState != .none else { return }
+    .onChange(of: viewModel.chatErrorState) { oldState, newState in
+      // Only track when error first appears — not on transitions between error states
+      guard oldState == .none, newState != .none else { return }
       DocAssistEventManager.shared.trackEvent(
         event: .docAssistLandingPgClick,
         properties: [

--- a/Sources/ViewModel/ChatViewModel.swift
+++ b/Sources/ViewModel/ChatViewModel.swift
@@ -1,4 +1,3 @@
-//
 //  ChatViewModel.swift
 //  Chatbot
 //
@@ -770,12 +769,13 @@ extension ChatViewModel {
       switch errorCode {
         
       case .sessionInactive, .sessionTokenMismatch:
-        WebSocketLogger.shared.logInfo("Error: \(rawCode) — prompting user retry. msg: \(rawMsg)")
+        // Session is truly invalid — retry with same token won't work, user must start a new session
+        WebSocketLogger.shared.logInfo("Error: \(rawCode) — session truly expired, prompting new session. msg: \(rawMsg)")
         await MainActor.run {
           lastSessionRecoveryReason = rawCode
-          webSocketConnectionTitle = "Session refresh needed"
-          webSocketErrorMessage = "Session expired. Tap Retry to continue."
-          chatErrorState = .connectionError
+          webSocketConnectionTitle = "Session expired"
+          webSocketErrorMessage = "Session expired. Please start a new session."
+          chatErrorState = .sessionExpired
         }
         
       case .invalidEvent, .invalidContentType:

--- a/Sources/ViewModel/ChatViewModel.swift
+++ b/Sources/ViewModel/ChatViewModel.swift
@@ -64,6 +64,7 @@ public final class ChatViewModel: NSObject, URLSessionDataDelegate {
   var initialMessageSuggestions: [String]? = nil
   var chatErrorState: ChatErrorState = .none
   var webSocketErrorMessage: String? = nil
+  var lastSessionRecoveryReason: String? = nil
   var isWebSocketSetupDone: Bool = false
   
   var showPermissionAlertBinding: Binding<Bool> {
@@ -383,6 +384,7 @@ extension ChatViewModel {
       print("#BB Session has expired — showing refresh banner")
       WebSocketLogger.shared.logInfo("Session \(webSocketSessionId) is no longer active — prompting user to refresh")
       await MainActor.run {
+        lastSessionRecoveryReason = "session_check_expired"
         webSocketErrorMessage = "Session expired. Tap to refresh."
         chatErrorState = .connectionError
       }
@@ -461,6 +463,9 @@ extension ChatViewModel {
           }
         case .failure(let error):
           print("#BB refreshSession failure:", error.localizedDescription)
+          Task { @MainActor in
+              self.lastSessionRecoveryReason = "refresh_failed"
+          }
           continuation.resume(returning: nil)
         }
       }
@@ -473,18 +478,27 @@ extension ChatViewModel {
       webSocketConnectionTitle = "Not connected"
       return
     }
-
-    webSocketClient = WebSocketNetworkRequest(url: url)
-    webSocketClient?.onMessageDecoded = { [weak self] model in
+    await MainActor.run {
+      webSocketConnectionTitle = "Connecting..."
+    }
+    
+    // Always tear down any existing socket before opening a new one
+    // so token refresh re-auth starts from a clean transport.
+    webSocketClient?.disconnect()
+    
+    let socketClient = WebSocketNetworkRequest(url: url)
+    webSocketClient = socketClient
+    socketClient.onMessageDecoded = { [weak self] model in
       guard let self else { return }
       serialTaskQueue.enqueue { [weak self] in
         guard let self else { return }
         await handleWebSocketModel(model)
       }
     }
-    webSocketClient?.onConnectionError = { [weak self] error in
+    socketClient.onConnectionError = { [weak self] error in
       guard let self else { return }
       Task { @MainActor in
+        self.lastSessionRecoveryReason = "websocket_transport_error"
         self.webSocketConnectionTitle = "Something went wrong"
         self.webSocketErrorMessage = "Something went wrong. Please try again."
         self.chatErrorState = .connectionError
@@ -492,7 +506,7 @@ extension ChatViewModel {
         print("❌ WebSocket connection dropped: \(error.localizedDescription)")
       }
     }
-    webSocketClient?.connect { [weak self] connected in
+    socketClient.connect { [weak self, weak socketClient] connected in
       guard connected else {
         print("❌ WebSocket connection failed")
         WebSocketLogger.shared.logInfo("Error: WebSocket initial connection failed to \(url)")
@@ -521,7 +535,7 @@ extension ChatViewModel {
         let jsonData = try JSONSerialization.data(withJSONObject: authPayload, options: [])
         if let jsonString = String(data: jsonData, encoding: .utf8) {
           print("📤 Sending auth message: \(jsonString)")
-          self?.webSocketClient?.send(message: jsonString)
+          socketClient?.send(message: jsonString)
         }
       } catch {
         print("❌ Failed to encode auth payload: \(error)")
@@ -756,19 +770,12 @@ extension ChatViewModel {
       switch errorCode {
         
       case .sessionInactive, .sessionTokenMismatch:
-        // Architecture: try refresh + re-authenticate before forcing a new session.
-        WebSocketLogger.shared.logInfo("Error: \(rawCode) — attempting refresh before forcing new session. msg: \(rawMsg)")
-        if let newToken = await refreshSession(for: vmssid) {
-          WebSocketLogger.shared.logInfo("Refresh succeeded after \(rawCode) — re-authenticating WebSocket")
-          await webSocketAuthentication(sessionId: vmssid, sessionToken: newToken)
-        } else {
-          // Refresh failed — session is truly gone, user must start a new one.
-          WebSocketLogger.shared.logInfo("Error state: sessionExpired — refresh failed after \(rawCode), msg: \(rawMsg)")
-          await MainActor.run {
-            webSocketConnectionTitle = "Session not found"
-            webSocketErrorMessage = "Session not found. Please start a new session."
-            chatErrorState = .sessionExpired
-          }
+        WebSocketLogger.shared.logInfo("Error: \(rawCode) — prompting user retry. msg: \(rawMsg)")
+        await MainActor.run {
+          lastSessionRecoveryReason = rawCode
+          webSocketConnectionTitle = "Session refresh needed"
+          webSocketErrorMessage = "Session expired. Tap Retry to continue."
+          chatErrorState = .connectionError
         }
         
       case .invalidEvent, .invalidContentType:
@@ -776,42 +783,30 @@ extension ChatViewModel {
         print("⚠️ Ignorable WebSocket error (\(model.data?.code ?? ""))")
         
       case .parsingError:
-        WebSocketLogger.shared.logInfo("Error: parsingError — code: \(rawCode), msg: \(rawMsg). Attempting session refresh...")
-        if let newToken = await refreshSession(for: vmssid) {
-          await webSocketAuthentication(sessionId: vmssid, sessionToken: newToken)
-        } else {
-          WebSocketLogger.shared.logInfo("Error state: connectionError — parsingError, session refresh failed. code: \(rawCode), msg: \(rawMsg)")
-          await MainActor.run {
-            webSocketConnectionTitle = "Error parsing request"
-            webSocketErrorMessage = "Error parsing request. Please try again."
-            chatErrorState = .connectionError
-          }
+        WebSocketLogger.shared.logInfo("Error: parsingError — code: \(rawCode), msg: \(rawMsg). Prompting retry...")
+        await MainActor.run {
+          lastSessionRecoveryReason = rawCode
+          webSocketConnectionTitle = "Error parsing request"
+          webSocketErrorMessage = "Something went wrong. Tap Retry to continue."
+          chatErrorState = .connectionError
         }
         
       case .timeout:
-        WebSocketLogger.shared.logInfo("Error: timeout — code: \(rawCode), msg: \(rawMsg). Attempting session refresh...")
-        if let newToken = await refreshSession(for: vmssid) {
-          await webSocketAuthentication(sessionId: vmssid, sessionToken: newToken)
-        } else {
-          WebSocketLogger.shared.logInfo("Error state: connectionError — timeout, session refresh failed. code: \(rawCode), msg: \(rawMsg)")
-          await MainActor.run {
-            webSocketConnectionTitle = "Request timed out"
-            webSocketErrorMessage = "Request timed out. Please try again."
-            chatErrorState = .connectionError
-          }
+        WebSocketLogger.shared.logInfo("Error: timeout — code: \(rawCode), msg: \(rawMsg). Prompting retry...")
+        await MainActor.run {
+          lastSessionRecoveryReason = rawCode
+          webSocketConnectionTitle = "Request timed out"
+          webSocketErrorMessage = "Request timed out. Tap Retry to continue."
+          chatErrorState = .connectionError
         }
         
       case .promptFetchError, .invalidFileRequest, .serverError, .none:
-        WebSocketLogger.shared.logInfo("Error: \(rawCode) — msg: \(rawMsg). Attempting session refresh...")
-        if let newToken = await refreshSession(for: vmssid) {
-          await webSocketAuthentication(sessionId: vmssid, sessionToken: newToken)
-        } else {
-          WebSocketLogger.shared.logInfo("Error state: connectionError — \(rawCode), session refresh failed. msg: \(rawMsg)")
-          await MainActor.run {
-            webSocketConnectionTitle = "Something went wrong"
-            webSocketErrorMessage = "Something went wrong. Please try again."
-            chatErrorState = .connectionError
-          }
+        WebSocketLogger.shared.logInfo("Error: \(rawCode) — msg: \(rawMsg). Prompting retry...")
+        await MainActor.run {
+          lastSessionRecoveryReason = rawCode
+          webSocketConnectionTitle = "Something went wrong"
+          webSocketErrorMessage = "Something went wrong. Tap Retry to continue."
+          chatErrorState = .connectionError
         }
       }
       
@@ -878,45 +873,39 @@ extension ChatViewModel {
     let sessionId = dbSession.sessionId
     print("#BB fetchExistingActiveSession — found DB session: \(sessionId), validating with server...")
 
-    // Architecture requires GET /session/{id} before establishing WebSocket.
-    let statusResult = await checkSessionStatus(for: sessionId)
-
-    switch statusResult {
-    case .active:
-      // Token may have been updated by checkSessionStatus — re-read from DB.
-      let latestToken = (try? await DatabaseConfig.shared.fetchSession(bySessionId: sessionId))?.sessionToken ?? dbSession.sessionToken ?? ""
-      print("#BB fetchExistingActiveSession — session active, connecting WebSocket")
-      activateSession(id: sessionId, token: latestToken)
-      Task {
-        await webSocketAuthentication(sessionId: sessionId, sessionToken: latestToken)
-      }
-      return sessionId
-
-    case .expired:
-      // Session is gone on server — try to refresh it.
-      print("#BB fetchExistingActiveSession — session expired, attempting refresh")
-      if let newToken = await refreshSession(for: sessionId) {
-        print("#BB fetchExistingActiveSession — refresh succeeded, connecting WebSocket")
-        activateSession(id: sessionId, token: newToken)
-        Task {
-          await webSocketAuthentication(sessionId: sessionId, sessionToken: newToken)
-        }
-        return sessionId
-      }
-      // Refresh also failed — fall through to create a new session.
-      print("#BB fetchExistingActiveSession — refresh failed, will create new session")
-      return nil
-
-    case .networkError:
-      // Transient failure — trust the DB token and proceed rather than blocking the user.
-      let token = dbSession.sessionToken ?? ""
-      print("#BB fetchExistingActiveSession — network error during validation, proceeding with cached token")
-      activateSession(id: sessionId, token: token)
-      Task {
-        await webSocketAuthentication(sessionId: sessionId, sessionToken: token)
-      }
-      return sessionId
+    // Fast path: connect immediately with cached token instead of waiting
+    // for validation network call, which can delay auth by several seconds.
+    let cachedToken = dbSession.sessionToken ?? ""
+    print("#BB fetchExistingActiveSession — connecting immediately with cached token")
+    activateSession(id: sessionId, token: cachedToken)
+    Task {
+      await webSocketAuthentication(sessionId: sessionId, sessionToken: cachedToken)
     }
+
+    // Validate in background and adjust only if needed.
+    Task { [weak self] in
+      guard let self else { return }
+      let statusResult = await checkSessionStatus(for: sessionId)
+      switch statusResult {
+      case .active:
+        // Token may have been rotated on server; if changed, re-auth quickly.
+        let latestToken = (try? await DatabaseConfig.shared.fetchSession(bySessionId: sessionId))?.sessionToken ?? cachedToken
+        if !latestToken.isEmpty, latestToken != cachedToken {
+          WebSocketLogger.shared.logInfo("Session validated active with rotated token — reconnecting with latest token")
+          await webSocketAuthentication(sessionId: sessionId, sessionToken: latestToken)
+        }
+      case .expired:
+        await MainActor.run {
+          self.lastSessionRecoveryReason = "existing_session_expired"
+          self.webSocketConnectionTitle = "Session expired"
+          self.webSocketErrorMessage = "Session expired. Tap Retry to refresh."
+          self.chatErrorState = .connectionError
+        }
+      case .networkError:
+        break
+      }
+    }
+    return sessionId
   }
   
   public func createNewSession(

--- a/Sources/ViewModel/ChatViewModel.swift
+++ b/Sources/ViewModel/ChatViewModel.swift
@@ -505,7 +505,7 @@ extension ChatViewModel {
         print("❌ WebSocket connection dropped: \(error.localizedDescription)")
       }
     }
-    socketClient.connect { [weak self, weak socketClient] connected in
+    socketClient.connect { [weak self] connected in
       guard connected else {
         print("❌ WebSocket connection failed")
         WebSocketLogger.shared.logInfo("Error: WebSocket initial connection failed to \(url)")
@@ -529,12 +529,13 @@ extension ChatViewModel {
         ]
       ]
       
-      // Convert to JSON string
+      // Convert to JSON string — use self.webSocketClient (the property) rather than
+      // a weak-captured local variable, which may be nil by the time this callback fires.
       do {
         let jsonData = try JSONSerialization.data(withJSONObject: authPayload, options: [])
         if let jsonString = String(data: jsonData, encoding: .utf8) {
           print("📤 Sending auth message: \(jsonString)")
-          socketClient?.send(message: jsonString)
+          self?.webSocketClient?.send(message: jsonString)
         }
       } catch {
         print("❌ Failed to encode auth payload: \(error)")

--- a/Sources/ViewModel/ChatViewModel.swift
+++ b/Sources/ViewModel/ChatViewModel.swift
@@ -350,19 +350,23 @@ extension Data {
 extension ChatViewModel {
   
   func checkandValidateWebSocketConnection() async {
-    let webSocketSessionId = UserDefaults.standard.string(forKey: "SessionId")
-    WebSocketLogger.shared.logInfo("checkandValidateWebSocketConnection called — sessionId: \(webSocketSessionId ?? "nil")")
-    guard let webSocketSessionId else {
-      WebSocketLogger.shared.logInfo("No SessionId in UserDefaults — skipping reconnection")
+    // Always fetch session from DB scoped to this user — never from UserDefaults.
+    guard let dbSession = try? await DatabaseConfig.shared
+      .fetchSessionIdwithoutoid(userDocId: userDocId, userBId: userBid)
+      .last else {
+      WebSocketLogger.shared.logInfo("checkandValidateWebSocketConnection — no session in DB for user, skipping reconnection")
       return
     }
+
+    let webSocketSessionId = dbSession.sessionId
+    let token = dbSession.sessionToken ?? ""
+    WebSocketLogger.shared.logInfo("checkandValidateWebSocketConnection called — sessionId: \(webSocketSessionId)")
 
     let statusResult = await checkSessionStatus(for: webSocketSessionId)
     WebSocketLogger.shared.logInfo("Session check result: \(statusResult)")
 
     switch statusResult {
     case .active:
-      let token = UserDefaults.standard.string(forKey: "SessionToken") ?? ""
       if !token.isEmpty {
         await webSocketAuthentication(sessionId: webSocketSessionId, sessionToken: token)
       } else {
@@ -372,7 +376,6 @@ extension ChatViewModel {
       // Transient failure (auth token decode error, no network, interceptor retry failed).
       // Attempt to reconnect with the token we have rather than showing an error banner.
       WebSocketLogger.shared.logInfo("Session check had transient error — attempting reconnect with stored token")
-      let token = UserDefaults.standard.string(forKey: "SessionToken") ?? ""
       if !token.isEmpty {
         await webSocketAuthentication(sessionId: webSocketSessionId, sessionToken: token)
       }
@@ -414,7 +417,6 @@ extension ChatViewModel {
           DispatchQueue.main.async {
             self?.webSocketConnectionTitle = "Connected"
           }
-          UserDefaults.standard.set(serverToken, forKey: "SessionToken")
           Task {
             await DatabaseConfig.shared.updateSessionToken(sessionId: sessionId, sessionToken: serverToken)
           }
@@ -440,7 +442,8 @@ extension ChatViewModel {
 
   /// Returns the new session token from the server after a successful refresh, or `nil` on failure.
   func refreshSession(for sessionId: String) async -> String? {
-    let currentToken = UserDefaults.standard.string(forKey: "SessionToken") ?? ""
+    // Fetch current token from DB — never from UserDefaults to avoid cross-profile contamination.
+    let currentToken = (try? await DatabaseConfig.shared.fetchSession(bySessionId: sessionId))?.sessionToken ?? ""
     return await withCheckedContinuation { continuation in
       MatrixApiService.shared.refreshSession(sessionId: sessionId, sessionToken: currentToken) { result, _ in
         switch result {
@@ -452,7 +455,6 @@ extension ChatViewModel {
             continuation.resume(returning: nil)
             return
           }
-          UserDefaults.standard.set(newToken, forKey: "SessionToken")
           Task {
             await DatabaseConfig.shared.updateSessionToken(sessionId: sessionId, sessionToken: newToken)
             continuation.resume(returning: newToken)
@@ -754,11 +756,19 @@ extension ChatViewModel {
       switch errorCode {
         
       case .sessionInactive, .sessionTokenMismatch:
-        WebSocketLogger.shared.logInfo("Error state: sessionExpired — code: \(rawCode), msg: \(rawMsg)")
-        await MainActor.run {
-          webSocketConnectionTitle = "Session not found"
-          webSocketErrorMessage = "Session not found. Please start a new session."
-          chatErrorState = .sessionExpired
+        // Architecture: try refresh + re-authenticate before forcing a new session.
+        WebSocketLogger.shared.logInfo("Error: \(rawCode) — attempting refresh before forcing new session. msg: \(rawMsg)")
+        if let newToken = await refreshSession(for: vmssid) {
+          WebSocketLogger.shared.logInfo("Refresh succeeded after \(rawCode) — re-authenticating WebSocket")
+          await webSocketAuthentication(sessionId: vmssid, sessionToken: newToken)
+        } else {
+          // Refresh failed — session is truly gone, user must start a new one.
+          WebSocketLogger.shared.logInfo("Error state: sessionExpired — refresh failed after \(rawCode), msg: \(rawMsg)")
+          await MainActor.run {
+            webSocketConnectionTitle = "Session not found"
+            webSocketErrorMessage = "Session not found. Please start a new session."
+            chatErrorState = .sessionExpired
+          }
         }
         
       case .invalidEvent, .invalidContentType:
@@ -767,9 +777,8 @@ extension ChatViewModel {
         
       case .parsingError:
         WebSocketLogger.shared.logInfo("Error: parsingError — code: \(rawCode), msg: \(rawMsg). Attempting session refresh...")
-        let sessionId = UserDefaults.standard.string(forKey: "SessionId") ?? vmssid
-        if let newToken = await refreshSession(for: sessionId) {
-          await webSocketAuthentication(sessionId: sessionId, sessionToken: newToken)
+        if let newToken = await refreshSession(for: vmssid) {
+          await webSocketAuthentication(sessionId: vmssid, sessionToken: newToken)
         } else {
           WebSocketLogger.shared.logInfo("Error state: connectionError — parsingError, session refresh failed. code: \(rawCode), msg: \(rawMsg)")
           await MainActor.run {
@@ -781,9 +790,8 @@ extension ChatViewModel {
         
       case .timeout:
         WebSocketLogger.shared.logInfo("Error: timeout — code: \(rawCode), msg: \(rawMsg). Attempting session refresh...")
-        let sessionId = UserDefaults.standard.string(forKey: "SessionId") ?? vmssid
-        if let newToken = await refreshSession(for: sessionId) {
-          await webSocketAuthentication(sessionId: sessionId, sessionToken: newToken)
+        if let newToken = await refreshSession(for: vmssid) {
+          await webSocketAuthentication(sessionId: vmssid, sessionToken: newToken)
         } else {
           WebSocketLogger.shared.logInfo("Error state: connectionError — timeout, session refresh failed. code: \(rawCode), msg: \(rawMsg)")
           await MainActor.run {
@@ -795,9 +803,8 @@ extension ChatViewModel {
         
       case .promptFetchError, .invalidFileRequest, .serverError, .none:
         WebSocketLogger.shared.logInfo("Error: \(rawCode) — msg: \(rawMsg). Attempting session refresh...")
-        let sessionId = UserDefaults.standard.string(forKey: "SessionId") ?? vmssid
-        if let newToken = await refreshSession(for: sessionId) {
-          await webSocketAuthentication(sessionId: sessionId, sessionToken: newToken)
+        if let newToken = await refreshSession(for: vmssid) {
+          await webSocketAuthentication(sessionId: vmssid, sessionToken: newToken)
         } else {
           WebSocketLogger.shared.logInfo("Error state: connectionError — \(rawCode), session refresh failed. msg: \(rawMsg)")
           await MainActor.run {
@@ -859,45 +866,57 @@ extension ChatViewModel {
   }
   
   private func fetchExistingActiveSession(userDocId: String, userBId: String) async -> String? {
-    // Prefer UserDefaults SessionId — it survives DB cleanup of empty sessions.
-    // Trust it without a server round-trip here; WebSocket connection will validate it.
-    // Only fall back to the DB if UserDefaults has nothing.
-    let sessionId: String
-    let token: String
-
-    if let udId = UserDefaults.standard.string(forKey: "SessionId"), !udId.isEmpty {
-      sessionId = udId
-      token = UserDefaults.standard.string(forKey: "SessionToken") ?? ""
-      print("#BB fetchExistingActiveSession — reusing UserDefaults session: \(sessionId)")
-    } else if let dbSession = try? await DatabaseConfig.shared
+    // Always fetch from DB scoped to this user — never from UserDefaults,
+    // which is shared across profiles and would return the wrong session.
+    guard let dbSession = try? await DatabaseConfig.shared
       .fetchSessionIdwithoutoid(userDocId: userDocId, userBId: userBId)
-      .last {
-      sessionId = dbSession.sessionId
-      token = dbSession.sessionToken ?? ""
-      print("#BB fetchExistingActiveSession — reusing DB session: \(sessionId)")
-    } else {
+      .last else {
       print("#BB fetchExistingActiveSession — no existing session found, will create new")
       return nil
     }
 
-    // Re-insert into DB if it was cleaned up (empty-session deletion on disappear)
-    if (try? await DatabaseConfig.shared.fetchSession(bySessionId: sessionId)) == nil {
-      let _ = await DatabaseConfig.shared.createSession(
-        subTitle: nil,
-        oid: "",
-        userDocId: userDocId,
-        userBId: userBId,
-        sessionId: sessionId,
-        sessionToken: token
-      )
-      print("#BB re-inserted session \(sessionId) into DB after cleanup")
-    }
+    let sessionId = dbSession.sessionId
+    print("#BB fetchExistingActiveSession — found DB session: \(sessionId), validating with server...")
 
-    activateSession(id: sessionId, token: token)
-    Task {
-      await webSocketAuthentication(sessionId: sessionId, sessionToken: token)
+    // Architecture requires GET /session/{id} before establishing WebSocket.
+    let statusResult = await checkSessionStatus(for: sessionId)
+
+    switch statusResult {
+    case .active:
+      // Token may have been updated by checkSessionStatus — re-read from DB.
+      let latestToken = (try? await DatabaseConfig.shared.fetchSession(bySessionId: sessionId))?.sessionToken ?? dbSession.sessionToken ?? ""
+      print("#BB fetchExistingActiveSession — session active, connecting WebSocket")
+      activateSession(id: sessionId, token: latestToken)
+      Task {
+        await webSocketAuthentication(sessionId: sessionId, sessionToken: latestToken)
+      }
+      return sessionId
+
+    case .expired:
+      // Session is gone on server — try to refresh it.
+      print("#BB fetchExistingActiveSession — session expired, attempting refresh")
+      if let newToken = await refreshSession(for: sessionId) {
+        print("#BB fetchExistingActiveSession — refresh succeeded, connecting WebSocket")
+        activateSession(id: sessionId, token: newToken)
+        Task {
+          await webSocketAuthentication(sessionId: sessionId, sessionToken: newToken)
+        }
+        return sessionId
+      }
+      // Refresh also failed — fall through to create a new session.
+      print("#BB fetchExistingActiveSession — refresh failed, will create new session")
+      return nil
+
+    case .networkError:
+      // Transient failure — trust the DB token and proceed rather than blocking the user.
+      let token = dbSession.sessionToken ?? ""
+      print("#BB fetchExistingActiveSession — network error during validation, proceeding with cached token")
+      activateSession(id: sessionId, token: token)
+      Task {
+        await webSocketAuthentication(sessionId: sessionId, sessionToken: token)
+      }
+      return sessionId
     }
-    return sessionId
   }
   
   public func createNewSession(
@@ -954,8 +973,6 @@ extension ChatViewModel {
   }
   
   private func activateSession(id: String, token: String) {
-    UserDefaults.standard.set(id, forKey: "SessionId")
-    UserDefaults.standard.set(token, forKey: "SessionToken")
     switchToSession(id)
     isWebSocketSetupDone = true
   }


### PR DESCRIPTION
Migrates session management from UserDefaults to database-only storage and adds comprehensive analytics tracking for session recovery flows.
Key Changes
1. Remove UserDefaults Dependency

Before: Sessions stored in both UserDefaults and database, causing cross-profile contamination
After: Database is the single source of truth for all session data
Impact: Prevents session leakage when switching between user profiles

Files Changed:

ChatViewModel.swift: Removed all UserDefaults.standard.get/set for SessionId/SessionToken
All session fetches now use DatabaseConfig.shared.fetchSession*() methods

2. Session Recovery Analytics
Added comprehensive event tracking for debugging production issues:

session_recovery_banner_shown - Error banner displayed to user
session_recovery_retry_clicked - User tapped retry button
session_recovery_retry_success/failed - Retry outcome
session_recovery_start_new_clicked/success - New session creation flow

Properties tracked: session_id, error_state, error_reason, error_message
3. Improved Error Handling

Added lastSessionRecoveryReason property to track error context
Fixed error state for sessionInactive/sessionTokenMismatch → now correctly shows .sessionExpired (requires new session) instead of .connectionError (retry)
Simplified error handling - removed auto-refresh attempts, now prompts user to retry

4. WebSocket Connection Improvements

Always disconnect existing socket before creating new connection
Fast-path connection: authenticate immediately with cached token, validate in background
Better connection state management ("Connecting...", "Connected", error states)
Fixed callback reference: use self?.webSocketClient instead of weak local variable

5. Cleanup

Removed empty session cleanup logic from onDisappear (intentional - handled elsewhere)
Removed obsolete UserDefaults re-insertion logic
Cleaner error messages with consistent "Tap Retry to continue" wording